### PR TITLE
Fix Typo chart autoscaling

### DIFF
--- a/charts/cloud-pricing-api/templates/api-hpa.yaml
+++ b/charts/cloud-pricing-api/templates/api-hpa.yaml
@@ -11,7 +11,7 @@ spec:
     kind: Deployment
     name: {{ include "cloud-pricing-api.fullname" . }}
   minReplicas: {{ .Values.api.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.api.utoscaling.maxReplicas }}
+  maxReplicas: {{ .Values.api.autoscaling.maxReplicas }}
   metrics:
     {{- if .Values.api.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource


### PR DESCRIPTION
Just fixing some typo. 
This error prevents running with Autoscaling configuration enabled. 

Just a small fix!