### PR TITLE
Deployment Resources

### DIFF
--- a/charts/cloud-pricing-api/templates/api-deployment.yaml
+++ b/charts/cloud-pricing-api/templates/api-deployment.yaml
@@ -32,10 +32,17 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          resources:
+           limits:
+             cpu: {{ .Values.deployment.resources.limits.cpu }}
+             memory: {{ .Values.deployment.resources.limit.memory }}
+           requests:
+             cpu: {{ .Values.deployment.resources.requests.cpu }}
+             memory: {{ .Values.deployment.resources.requests.memory }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 4000

--- a/charts/cloud-pricing-api/templates/api-deployment.yaml
+++ b/charts/cloud-pricing-api/templates/api-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           resources:
            limits:
              cpu: {{ .Values.deployment.resources.limits.cpu }}
-             memory: {{ .Values.deployment.resources.limit.memory }}
+             memory: {{ .Values.deployment.resources.limits.memory }}
            requests:
              cpu: {{ .Values.deployment.resources.requests.cpu }}
              memory: {{ .Values.deployment.resources.requests.memory }}

--- a/charts/cloud-pricing-api/templates/job-cron.yaml
+++ b/charts/cloud-pricing-api/templates/job-cron.yaml
@@ -32,8 +32,8 @@ spec:
             - name: {{ .Chart.Name }}
               securityContext:
                 {{- toYaml .Values.securityContext | nindent 16 }}
-              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
               command: ["npm", "run", "job:update"]
               resources:
                 {{- toYaml .Values.job.resources | nindent 16 }}

--- a/charts/cloud-pricing-api/templates/job-init.yaml
+++ b/charts/cloud-pricing-api/templates/job-init.yaml
@@ -26,8 +26,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 16 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           command: ["npm",  "run", "job:init"]
           resources:
             {{- toYaml .Values.job.resources | nindent 16 }}

--- a/charts/cloud-pricing-api/values.yaml
+++ b/charts/cloud-pricing-api/values.yaml
@@ -5,16 +5,25 @@
 # -- Use the [Infracost CLI](https://github.com/infracost/infracost/blob/master/README.md#quick-start) `infracost register` command to get an API key so your self-hosted Cloud Pricing API can download the latest pricing data from us.
 infracostAPIKey: ""
 
-image:
-  # -- Cloud Pricing API image
-  repository: infracost/cloud-pricing-api
+deployment:
+  image:
+    # -- Cloud Pricing API image
+    repository: infracost/cloud-pricing-api
 
-  # -- Image pull policy
-  # pullPolicy: IfNotPresent
-  pullPolicy: Always
+    # -- Image pull policy
+    # pullPolicy: IfNotPresent
+    pullPolicy: Always
 
-  # -- Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+    # -- Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+    # -- Kubernetes default resources
+    resources:                                                                                                                                                                                                   │
+      limits:                                                                                                                                                                                                    │
+        cpu: 150m                                                                                                                                                                                                │
+        memory: 128Mi                                                                                                                                                                                            │
+      requests:                                                                                                                                                                                                  │
+        cpu: 50m                                                                                                                                                                                                 │
+        memory: 64Mi
 
 # -- Any image pull secrets
 imagePullSecrets: []

--- a/charts/cloud-pricing-api/values.yaml
+++ b/charts/cloud-pricing-api/values.yaml
@@ -17,12 +17,12 @@ deployment:
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: ""
     # -- Kubernetes default resources
-    resources:                                                                                                                                                                                                   │
-      limits:                                                                                                                                                                                                    │
-        cpu: 150m                                                                                                                                                                                                │
-        memory: 128Mi                                                                                                                                                                                            │
-      requests:                                                                                                                                                                                                  │
-        cpu: 50m                                                                                                                                                                                                 │
+    resources:
+      limits:
+        cpu: 150m
+        memory: 128Mi
+      requests:
+        cpu: 50m
         memory: 64Mi
 
 # -- Any image pull secrets
@@ -47,11 +47,13 @@ serviceAccount:
 podAnnotations: {}
 
 # -- The pod security context
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
 # -- The container security context
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -69,7 +71,8 @@ ingress:
   # -- Enable the ingress controller resource
   enabled: false
   # -- Ingress annotation
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   # extraPaths:
@@ -81,8 +84,8 @@ ingress:
     - # -- Host name
       host: cloud-pricing-api.local
       paths:
-      - # -- Path for host
-        path: /
+        - # -- Path for host
+          path: /
 
   # -- TLS configuration
   tls: []
@@ -100,7 +103,7 @@ postgresql:
   # -- Name of the PostgreSQL database
   postgresqlDatabase: cloudpricingapi
   # -- Name of the PostgreSQL user
-  postgresqlUsername: cloudpricingapi  
+  postgresqlUsername: cloudpricingapi
   # -- Details of external PostgreSQL server, such as AWS RDS, to use (assuming you've set postgresql.enabled to false)
   external: {}
   #   host:
@@ -147,9 +150,9 @@ api:
     failureThreshold: 3
     # -- The readiness probe success threshold
     successThreshold: 1
-  
+
   autoscaling:
-    # -- Create a HorizontalPodAutoscaler for the API 
+    # -- Create a HorizontalPodAutoscaler for the API
     enabled: false
     # -- The minimum replicas for the API autoscaler
     minReplicas: 1
@@ -161,7 +164,8 @@ api:
     # targetMemoryUtilizationPercentage: 80
 
   # -- API resource limits and requests, our recommendations are commented-out per Helm best practices.
-  resources: {}
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -190,7 +194,8 @@ job:
   # -- Job backoff limit
   backoffLimit: 6
   # -- Job schedule
-  schedule: "0 4 * * SUN"
+  schedule:
+    "0 4 * * SUN"
     # -- Set this to debug, info, warn or error
   logLevel: info
   # -- History limit for successful jobs
@@ -201,7 +206,8 @@ job:
   startingDeadlineSeconds: 3600
 
   # -- Job resource limits and requests, our recommendations are commented-out per Helm best practices.
-  resources: {}
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/cloud-pricing-api/values.yaml
+++ b/charts/cloud-pricing-api/values.yaml
@@ -17,13 +17,13 @@ deployment:
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: ""
     # -- Kubernetes default resources
-    resources:
-      limits:
-        cpu: 150m
-        memory: 128Mi
-      requests:
-        cpu: 50m
-        memory: 64Mi
+  resources:
+    limits:
+      cpu: 150m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
 
 # -- Any image pull secrets
 imagePullSecrets: []


### PR DESCRIPTION
We have been using this in production and caught some weird scaling behaviour due to the lack of proper resource configuration. 
On our estimative, these values that i've entered ane enough for our purpose, please review.

We are currently running a minimum of 3 pods and HPA is configured to scale at 80% target cpu but to calculate cpu utilization, the auto-scaler need to compare with the cpu request inputed in the deployment.

To maintain the pattern, i've moved the image on values to a deployment bracket.

```yaml
deployment:
  image:
    ...
  resources:
    ...
```