### PR TITLE
feat(ingress): add new ingress class field value for k8s 1.18+

### DIFF
--- a/charts/cloud-pricing-api/README.md
+++ b/charts/cloud-pricing-api/README.md
@@ -1,6 +1,6 @@
 # Cloud Pricing API
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
 
 A Helm chart for running the Infracost [Cloud Pricing API](https://github.com/infracost/cloud-pricing-api).
 
@@ -103,6 +103,7 @@ The best way to get instructions for configuring Infracost to use the self-hoste
 | imagePullSecrets | list | `[]` | Any image pull secrets |
 | infracostAPIKey | string | `""` | Use the [Infracost CLI](https://github.com/infracost/infracost/blob/master/README.md#quick-start) `infracost register` command to get an API key so your self-hosted Cloud Pricing API can download the latest pricing data from us. |
 | ingress.annotations | object | `{}` | Ingress annotation |
+| ingress.className | string | `""` | Ingress class field that replace the kubernetes.io/ingress.class annotation starting at kubernetes 1.18 |
 | ingress.enabled | bool | `false` | Enable the ingress controller resource |
 | ingress.hosts[0].host | string | `"cloud-pricing-api.local"` | Host name |
 | ingress.hosts[0].paths[0].path | string | `"/"` | Path for host |

--- a/charts/cloud-pricing-api/templates/ingress.yaml
+++ b/charts/cloud-pricing-api/templates/ingress.yaml
@@ -17,6 +17,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/cloud-pricing-api/values.yaml
+++ b/charts/cloud-pricing-api/values.yaml
@@ -84,6 +84,9 @@ ingress:
   #    hosts:
   #      - cloud-pricing-api.local
 
+  # -- Ingress class field that replace the kubernetes.io/ingress.class annotation starting at kubernetes 1.18
+  className: ""
+
 postgresql:
   # -- Deploy PostgreSQL servers. See [below](#postgresql) for more details
   enabled: true


### PR DESCRIPTION
# Description

K8s 1.18 introduced a specific field to select the ingress class this proposal ensure the field can be set.

The ingress.class annotation is deprecated starting at 1.19 if nginx-controller uses v4 (the annotation works well until v3)

https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

