### PR TITLE
Enable extra sidecar containers on Cloud Pricing API

### DIFF
--- a/charts/cloud-pricing-api/Chart.yaml
+++ b/charts/cloud-pricing-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.6
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloud-pricing-api/README.md
+++ b/charts/cloud-pricing-api/README.md
@@ -1,6 +1,6 @@
 # Cloud Pricing API
 
-![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.3](https://img.shields.io/badge/AppVersion-v0.3.3-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.3](https://img.shields.io/badge/AppVersion-v0.3.3-informational?style=flat-square)
 
 A Helm chart for running the Infracost [Cloud Pricing API](https://github.com/infracost/cloud-pricing-api).
 
@@ -78,6 +78,7 @@ The best way to get instructions for configuring Infracost to use the self-hoste
 | api.autoscaling.minReplicas | int | `1` | The minimum replicas for the API autoscaler |
 | api.autoscaling.targetCPUUtilizationPercentage | int | `80` | The target CPU threshold for the API autoscaler |
 | api.disableTelemetry | bool | `false` | Set this to true to opt-out of telemetry |
+| api.extraContainers | list | `[]` | API extra sidecar containers |
 | api.livenessProbe.enabled | bool | `true` | Enable the liveness probe |
 | api.livenessProbe.failureThreshold | int | `3` | The liveness probe failure threshold |
 | api.livenessProbe.initialDelaySeconds | int | `5` | The liveness probe initial delay seconds |
@@ -94,7 +95,7 @@ The best way to get instructions for configuring Infracost to use the self-hoste
 | api.readinessProbe.timeoutSeconds | int | `2` | The readiness probe timeout seconds |
 | api.replicaCount | int | `1` | Replica count |
 | api.resources | object | `{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | API resource limits and requests, our request recommendations are based on minimal requirements and the limit recommendations are based on usage in a high-traffic production environment. If you are running on environments like Minikube you may wish to remove these recommendations. |
-| api.selfHostedInfracostAPIKey | string | `""` | A 32 character API token that your Infracost CLI users will use to authenticate when calling your self-hosted Cloud Pricing API. If left empty, the helm chat will generate one for you. --  If you ever need to rotate the API key, you can simply update `self-hosted-infracost-api-key` in the `cloud-pricing-api` secret and restart the application. |
+| api.selfHostedInfracostAPIKey | string | `""` | If you ever need to rotate the API key, you can simply update `self-hosted-infracost-api-key` in the `cloud-pricing-api` secret and restart the application. |
 | api.tolerations | list | `[]` | API tolerations |
 | fullnameOverride | string | `""` | Full name override for the deployed app |
 | image.pullPolicy | string | `"Always"` | Image pull policy pullPolicy: IfNotPresent |
@@ -110,6 +111,7 @@ The best way to get instructions for configuring Infracost to use the self-hoste
 | ingress.tls | list | `[]` | TLS configuration |
 | job.affinity | object | `{}` | Job affinity |
 | job.backoffLimit | int | `6` | Job backoff limit |
+| job.extraContainers | list | `[]` | Job extra sidecar containers |
 | job.failedJobsHistoryLimit | int | `5` | History limit for failed jobs |
 | job.logLevel | string | `"info"` | Set this to debug, info, warn or error |
 | job.nodeSelector | object | `{}` | Job node selector |
@@ -199,7 +201,7 @@ helm install cloud-pricing-api infracost/cloud-pricing-api \
 
 Use the following commands to upgrade to the latest released version of the Cloud Pricing API and Helm chart; you should pass-in any variables that you set during install with `--set`:
 ```
-kubectl delete job -n my-namespace cloud-pricing-api-init-job
+kubectl delete job -n my-namespace hosted-cloud-pricing-api-init-job
 
 helm upgrade cloud-pricing-api infracost/cloud-pricing-api \
     --set infracostAPIKey="YOUR_INFRACOST_API_KEY_HERE" \

--- a/charts/cloud-pricing-api/templates/api-deployment.yaml
+++ b/charts/cloud-pricing-api/templates/api-deployment.yaml
@@ -31,6 +31,9 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.api.terminationGracePeriodSeconds }}
       {{- end }}
       containers:
+        {{- with .Values.api.extraContainers }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/cloud-pricing-api/templates/job-cron.yaml
+++ b/charts/cloud-pricing-api/templates/job-cron.yaml
@@ -29,6 +29,9 @@ spec:
           securityContext:
             {{- toYaml .Values.podSecurityContext | nindent 12 }}
           containers:
+            {{- with .Values.job.extraContainers }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             - name: {{ .Chart.Name }}
               securityContext:
                 {{- toYaml .Values.securityContext | nindent 16 }}

--- a/charts/cloud-pricing-api/templates/job-init.yaml
+++ b/charts/cloud-pricing-api/templates/job-init.yaml
@@ -26,6 +26,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 12 }}
       containers:
+        {{- with .Values.job.extraContainers }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 16 }}

--- a/charts/cloud-pricing-api/values.yaml
+++ b/charts/cloud-pricing-api/values.yaml
@@ -178,6 +178,9 @@ api:
   # -- The total time for the container to exit normally before being terminated. If specifying the preStopSleepSeconds, this value should be greater than that.
   # terminationGracePeriodSeconds: 60
 
+  # -- API extra sidecar containers
+  extraContainers: []
+
 job:
   # -- Run the job as a one-off on deploy
   runInitJob: true
@@ -212,3 +215,6 @@ job:
   tolerations: []
   # -- Job affinity
   affinity: {}
+
+  # -- Job extra sidecar containers
+  extraContainers: []


### PR DESCRIPTION
**Why is this PR necessary**?
To use CloudSQL authenticating through IAM as an external Postgres instance, I need to configure [cloud_sql_proxy](https://github.com/GoogleCloudPlatform/cloudsql-proxy) as a sidecar. This proposed change enables me to do so.

**References**:
https://cloud.google.com/sql/docs/mysql/connect-kubernetes-engine#run_the_as_a_sidecar

**Notes**:
The `helm-docs` changed the README.md beyond my intention.

