### PR TITLE
Update k8s api versions

### DIFF
--- a/charts/cloud-pricing-api/Chart.yaml
+++ b/charts/cloud-pricing-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloud-pricing-api/README.md
+++ b/charts/cloud-pricing-api/README.md
@@ -1,6 +1,6 @@
 # Cloud Pricing API
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.3](https://img.shields.io/badge/AppVersion-v0.3.3-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.3](https://img.shields.io/badge/AppVersion-v0.3.3-informational?style=flat-square)
 
 A Helm chart for running the Infracost [Cloud Pricing API](https://github.com/infracost/cloud-pricing-api).
 

--- a/charts/cloud-pricing-api/README.md
+++ b/charts/cloud-pricing-api/README.md
@@ -95,7 +95,7 @@ The best way to get instructions for configuring Infracost to use the self-hoste
 | api.readinessProbe.timeoutSeconds | int | `2` | The readiness probe timeout seconds |
 | api.replicaCount | int | `1` | Replica count |
 | api.resources | object | `{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | API resource limits and requests, our request recommendations are based on minimal requirements and the limit recommendations are based on usage in a high-traffic production environment. If you are running on environments like Minikube you may wish to remove these recommendations. |
-| api.selfHostedInfracostAPIKey | string | `""` | If you ever need to rotate the API key, you can simply update `self-hosted-infracost-api-key` in the `cloud-pricing-api` secret and restart the application. |
+| api.selfHostedInfracostAPIKey | string | `""` | A 32 character API token that your Infracost CLI users will use to authenticate when calling your self-hosted Cloud Pricing API. If left empty, the helm chat will generate one for you. If you ever need to rotate the API key, you can simply update `self-hosted-infracost-api-key` in the `cloud-pricing-api` secret and restart the application. |
 | api.tolerations | list | `[]` | API tolerations |
 | fullnameOverride | string | `""` | Full name override for the deployed app |
 | image.pullPolicy | string | `"Always"` | Image pull policy pullPolicy: IfNotPresent |
@@ -201,7 +201,7 @@ helm install cloud-pricing-api infracost/cloud-pricing-api \
 
 Use the following commands to upgrade to the latest released version of the Cloud Pricing API and Helm chart; you should pass-in any variables that you set during install with `--set`:
 ```
-kubectl delete job -n my-namespace hosted-cloud-pricing-api-init-job
+kubectl delete job -n my-namespace cloud-pricing-api-init-job
 
 helm upgrade cloud-pricing-api infracost/cloud-pricing-api \
     --set infracostAPIKey="YOUR_INFRACOST_API_KEY_HERE" \

--- a/charts/cloud-pricing-api/templates/ingress.yaml
+++ b/charts/cloud-pricing-api/templates/ingress.yaml
@@ -2,7 +2,9 @@
 {{- $fullName := include "cloud-pricing-api.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $extraPaths := .Values.ingress.extraPaths -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -41,8 +43,15 @@ spec:
           {{- range .paths }}
           - path: {{ .path }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/cloud-pricing-api/templates/job-cron.yaml
+++ b/charts/cloud-pricing-api/templates/job-cron.yaml
@@ -1,4 +1,8 @@
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: batch/v1
+{{- else -}}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ include "cloud-pricing-api.fullname" . }}-cronjob


### PR DESCRIPTION
Inspired by https://github.com/prometheus-community/helm-charts/blob/main/charts/alertmanager/templates/ingress.yaml#L9-L15

Fixes #15.

* `networking.k8s.io/v1beta1` is deprecated as of k8s 1.22.0 and has been replaced with `networking.k8s.io/v1` as of k8s 0.19.0
* `batch/v1beta1` will be deprecated as of k8s 1.25.0 and has been replaced with `batch/v1` as of k8s 1.21.0.