### PR TITLE
Adding mandatory `pathType` for host path ingress resource.

### DIFF
--- a/charts/cloud-pricing-api/Chart.yaml
+++ b/charts/cloud-pricing-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.3
+version: 0.5.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloud-pricing-api/README.md
+++ b/charts/cloud-pricing-api/README.md
@@ -108,7 +108,7 @@ The best way to get instructions for configuring Infracost to use the self-hoste
 | ingress.enabled | bool | `false` | Enable the ingress controller resource |
 | ingress.hosts[0].host | string | `"cloud-pricing-api.local"` | Host name |
 | ingress.hosts[0].paths[0].path | string | `"/"` | Path for host |
-| ingress.hosts[0].paths[0].pathType | string | `"implementationSpecific"` | Path type for this specific host path. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types |
+| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` | Path type for this specific host path. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types |
 | ingress.tls | list | `[]` | TLS configuration |
 | job.affinity | object | `{}` | Job affinity |
 | job.backoffLimit | int | `6` | Job backoff limit |

--- a/charts/cloud-pricing-api/README.md
+++ b/charts/cloud-pricing-api/README.md
@@ -1,6 +1,6 @@
 # Cloud Pricing API
 
-![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.5](https://img.shields.io/badge/AppVersion-v0.3.5-informational?style=flat-square)
+![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.5](https://img.shields.io/badge/AppVersion-v0.3.5-informational?style=flat-square)
 
 A Helm chart for running the Infracost [Cloud Pricing API](https://github.com/infracost/cloud-pricing-api).
 
@@ -108,6 +108,7 @@ The best way to get instructions for configuring Infracost to use the self-hoste
 | ingress.enabled | bool | `false` | Enable the ingress controller resource |
 | ingress.hosts[0].host | string | `"cloud-pricing-api.local"` | Host name |
 | ingress.hosts[0].paths[0].path | string | `"/"` | Path for host |
+| ingress.hosts[0].paths[0].pathType | string | `"implementationSpecific"` | Path type for this specific host path. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types |
 | ingress.tls | list | `[]` | TLS configuration |
 | job.affinity | object | `{}` | Job affinity |
 | job.backoffLimit | int | `6` | Job backoff limit |

--- a/charts/cloud-pricing-api/templates/ingress.yaml
+++ b/charts/cloud-pricing-api/templates/ingress.yaml
@@ -42,16 +42,18 @@ spec:
           {{- end }}
           {{- range .paths }}
           - path: {{ .path }}
+            {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: {{ .pathType }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
+            {{- else }}
+            backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
-              {{- end }}
+            {{- end }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/cloud-pricing-api/values.yaml
+++ b/charts/cloud-pricing-api/values.yaml
@@ -78,7 +78,7 @@ ingress:
         - # -- Path for host
           path: /
           # -- Path type for this specific host path. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
-          pathType: implementationSpecific
+          pathType: ImplementationSpecific
 
   # -- TLS configuration
   tls: []

--- a/charts/cloud-pricing-api/values.yaml
+++ b/charts/cloud-pricing-api/values.yaml
@@ -77,6 +77,7 @@ ingress:
       paths:
         - # -- Path for host
           path: /
+          # -- Path type for this specific host path. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
           pathType: implementationSpecific
 
   # -- TLS configuration

--- a/charts/cloud-pricing-api/values.yaml
+++ b/charts/cloud-pricing-api/values.yaml
@@ -77,6 +77,7 @@ ingress:
       paths:
         - # -- Path for host
           path: /
+          pathType: implementationSpecific
 
   # -- TLS configuration
   tls: []


### PR DESCRIPTION
According to k8s [documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types), `pathType` is mandatory,  Helm chart installation/upgrade is failing if this value doesn't exist. 
