### PR TITLE
Existing api key secret option

### DIFF
--- a/charts/cloud-pricing-api/Chart.yaml
+++ b/charts/cloud-pricing-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.6
+version: 0.5.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloud-pricing-api/README.md
+++ b/charts/cloud-pricing-api/README.md
@@ -103,6 +103,7 @@ The best way to get instructions for configuring Infracost to use the self-hoste
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Any image pull secrets |
 | infracostAPIKey | string | `""` | Use the [Infracost CLI](https://github.com/infracost/infracost/blob/master/README.md#quick-start) `infracost register` command to get an API key so your self-hosted Cloud Pricing API can download the latest pricing data from us. |
+| existingSecretAPIKey | string | `""` | Point to existing secret with infracostAPIKey in it. This allows to either create a secret directly or use external secrets provider. |
 | ingress.annotations | object | `{}` | Ingress annotation |
 | ingress.className | string | `""` | Ingress class field that replace the kubernetes.io/ingress.class annotation starting at kubernetes 1.18 |
 | ingress.enabled | bool | `false` | Enable the ingress controller resource |

--- a/charts/cloud-pricing-api/README.md
+++ b/charts/cloud-pricing-api/README.md
@@ -1,6 +1,6 @@
 # Cloud Pricing API
 
-![Version: 0.5.6](https://img.shields.io/badge/Version-0.5.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.5](https://img.shields.io/badge/AppVersion-v0.3.5-informational?style=flat-square)
+![Version: 0.5.7](https://img.shields.io/badge/Version-0.5.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.5](https://img.shields.io/badge/AppVersion-v0.3.5-informational?style=flat-square)
 
 A Helm chart for running the Infracost [Cloud Pricing API](https://github.com/infracost/cloud-pricing-api).
 
@@ -97,13 +97,13 @@ The best way to get instructions for configuring Infracost to use the self-hoste
 | api.resources | object | `{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | API resource limits and requests, our request recommendations are based on minimal requirements and the limit recommendations are based on usage in a high-traffic production environment. If you are running on environments like Minikube you may wish to remove these recommendations. |
 | api.selfHostedInfracostAPIKey | string | `""` | A 32 character API token that your Infracost CLI users will use to authenticate when calling your self-hosted Cloud Pricing API. If left empty, the helm chat will generate one for you. If you ever need to rotate the API key, you can simply update `self-hosted-infracost-api-key` in the `cloud-pricing-api` secret and restart the application. |
 | api.tolerations | list | `[]` | API tolerations |
+| existingSecretAPIKey | string | `""` | If you'd rather use your own secret you can leave the above empty and instead specify the name of your secret below |
 | fullnameOverride | string | `""` | Full name override for the deployed app |
 | image.pullPolicy | string | `"Always"` | Image pull policy pullPolicy: IfNotPresent |
 | image.repository | string | `"infracost/cloud-pricing-api"` | Cloud Pricing API image |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Any image pull secrets |
 | infracostAPIKey | string | `""` | Use the [Infracost CLI](https://github.com/infracost/infracost/blob/master/README.md#quick-start) `infracost register` command to get an API key so your self-hosted Cloud Pricing API can download the latest pricing data from us. |
-| existingSecretAPIKey | string | `""` | Point to existing secret with infracostAPIKey in it. This allows to either create a secret directly or use external secrets provider. |
 | ingress.annotations | object | `{}` | Ingress annotation |
 | ingress.className | string | `""` | Ingress class field that replace the kubernetes.io/ingress.class annotation starting at kubernetes 1.18 |
 | ingress.enabled | bool | `false` | Enable the ingress controller resource |

--- a/charts/cloud-pricing-api/templates/api-deployment.yaml
+++ b/charts/cloud-pricing-api/templates/api-deployment.yaml
@@ -86,7 +86,11 @@ spec:
             - name: INFRACOST_API_KEY
               valueFrom:
                 secretKeyRef:
+                  {{- if not .Values.existingSecretAPIKey }}
                   name: {{ include "cloud-pricing-api.fullname" . }}
+                  {{- else }}
+                  name: {{ .Values.apiKey.existingSecret }}
+                  {{- end }}
                   key: infracost-api-key
             {{- if not .Values.api.disableSelfHostedInfracostAPIKey }}
             - name: SELF_HOSTED_INFRACOST_API_KEY

--- a/charts/cloud-pricing-api/templates/job-cron.yaml
+++ b/charts/cloud-pricing-api/templates/job-cron.yaml
@@ -61,7 +61,11 @@ spec:
                 - name: INFRACOST_API_KEY
                   valueFrom:
                     secretKeyRef:
+                      {{- if not .Values.existingSecretAPIKey }}
                       name: {{ include "cloud-pricing-api.fullname" . }}
+                      {{- else }}
+                      name: {{ .Values.apiKey.existingSecret }}
+                      {{- end }}
                       key: infracost-api-key
                 {{- if .Values.job.infracostPricingAPIEndpoint }}
                 - name: INFRACOST_PRICING_API_ENDPOINT

--- a/charts/cloud-pricing-api/templates/job-init.yaml
+++ b/charts/cloud-pricing-api/templates/job-init.yaml
@@ -58,7 +58,11 @@ spec:
             - name: INFRACOST_API_KEY
               valueFrom:
                 secretKeyRef:
+                  {{- if not .Values.existingSecretAPIKey }}
                   name: {{ include "cloud-pricing-api.fullname" . }}
+                  {{- else }}
+                  name: {{ .Values.apiKey.existingSecret }}
+                  {{- end }}
                   key: infracost-api-key
             {{- if not .Values.api.disableSelfHostedInfracostAPIKey }}
             - name: SELF_HOSTED_INFRACOST_API_KEY

--- a/charts/cloud-pricing-api/templates/secrets.yaml
+++ b/charts/cloud-pricing-api/templates/secrets.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "cloud-pricing-api.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{-if not .Values.existingSecretAPIKey }}
+  {{- if not .Values.existingSecretAPIKey }}
   infracost-api-key: {{ .Values.infracostAPIKey | b64enc | quote }}
   {{- end }}
   {{- if .Values.api.selfHostedInfracostAPIKey }}

--- a/charts/cloud-pricing-api/templates/secrets.yaml
+++ b/charts/cloud-pricing-api/templates/secrets.yaml
@@ -10,7 +10,9 @@ metadata:
     {{- include "cloud-pricing-api.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{-if not .Values.existingSecretAPIKey }}
   infracost-api-key: {{ .Values.infracostAPIKey | b64enc | quote }}
+  {{- end }}
   {{- if .Values.api.selfHostedInfracostAPIKey }}
   self-hosted-infracost-api-key: {{ .Values.api.selfHostedInfracostAPIKey | b64enc | quote }}
   {{- else if not .Values.api.disableSelfHostedInfracostAPIKey }}

--- a/charts/cloud-pricing-api/values.yaml
+++ b/charts/cloud-pricing-api/values.yaml
@@ -4,6 +4,8 @@
 
 # -- Use the [Infracost CLI](https://github.com/infracost/infracost/blob/master/README.md#quick-start) `infracost register` command to get an API key so your self-hosted Cloud Pricing API can download the latest pricing data from us.
 infracostAPIKey: ""
+# -- If you'd rather use your own secret you can leave the above empty and instead specify the name of your secret below
+existingSecretAPIKey: ""
 
 image:
   # -- Cloud Pricing API image
@@ -116,6 +118,7 @@ api:
   # -- A 32 character API token that your Infracost CLI users will use to authenticate when calling your self-hosted Cloud Pricing API. If left empty, the helm chat will generate one for you.
   # If you ever need to rotate the API key, you can simply update `self-hosted-infracost-api-key` in the `cloud-pricing-api` secret and restart the application.
   selfHostedInfracostAPIKey: ""
+
   # -- Set this to true to opt-out of telemetry
   disableTelemetry: false
   # -- Set this to debug, info, warn or error

--- a/charts/cloud-pricing-api/values.yaml
+++ b/charts/cloud-pricing-api/values.yaml
@@ -118,7 +118,6 @@ api:
   # -- A 32 character API token that your Infracost CLI users will use to authenticate when calling your self-hosted Cloud Pricing API. If left empty, the helm chat will generate one for you.
   # If you ever need to rotate the API key, you can simply update `self-hosted-infracost-api-key` in the `cloud-pricing-api` secret and restart the application.
   selfHostedInfracostAPIKey: ""
-
   # -- Set this to true to opt-out of telemetry
   disableTelemetry: false
   # -- Set this to debug, info, warn or error


### PR DESCRIPTION
Before: No option for existing secret with infracostAPIKey

After: Possibility to use existing secret or external secret

Test: Deploy with this branch / see if DB gets populated