### PR TITLE
* Allow .Values.postgresql.existingSecret to be used for external Pos…

### DIFF
--- a/charts/cloud-pricing-api/Chart.yaml
+++ b/charts/cloud-pricing-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.7
+version: 0.5.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloud-pricing-api/README.md
+++ b/charts/cloud-pricing-api/README.md
@@ -1,6 +1,6 @@
 # Cloud Pricing API
 
-![Version: 0.5.7](https://img.shields.io/badge/Version-0.5.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.5](https://img.shields.io/badge/AppVersion-v0.3.5-informational?style=flat-square)
+![Version: 0.5.8](https://img.shields.io/badge/Version-0.5.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.5](https://img.shields.io/badge/AppVersion-v0.3.5-informational?style=flat-square)
 
 A Helm chart for running the Infracost [Cloud Pricing API](https://github.com/infracost/cloud-pricing-api).
 

--- a/charts/cloud-pricing-api/templates/_helpers.tpl
+++ b/charts/cloud-pricing-api/templates/_helpers.tpl
@@ -130,6 +130,10 @@ Get the PostgreSQL secret name
         {{- printf "%s" (include "cloud-pricing-api.postgresql.fullname" .) -}}
     {{- end -}}
 {{- else -}}
-    {{- printf "%s" (include "cloud-pricing-api.fullname" .) -}}
+    {{- if .Values.postgresql.existingSecret }}
+        {{- printf "%s" .Values.postgresql.existingSecret -}}
+    {{- else -}}
+      {{- printf "%s" (include "cloud-pricing-api.fullname" .) -}}
+    {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/cloud-pricing-api/templates/api-deployment.yaml
+++ b/charts/cloud-pricing-api/templates/api-deployment.yaml
@@ -89,7 +89,7 @@ spec:
                   {{- if not .Values.existingSecretAPIKey }}
                   name: {{ include "cloud-pricing-api.fullname" . }}
                   {{- else }}
-                  name: {{ .Values.apiKey.existingSecret }}
+                  name: {{ .Values.existingSecretAPIKey }}
                   {{- end }}
                   key: infracost-api-key
             {{- if not .Values.api.disableSelfHostedInfracostAPIKey }}

--- a/charts/cloud-pricing-api/templates/job-cron.yaml
+++ b/charts/cloud-pricing-api/templates/job-cron.yaml
@@ -64,7 +64,7 @@ spec:
                       {{- if not .Values.existingSecretAPIKey }}
                       name: {{ include "cloud-pricing-api.fullname" . }}
                       {{- else }}
-                      name: {{ .Values.apiKey.existingSecret }}
+                      name: {{ .Values.existingSecretAPIKey }}
                       {{- end }}
                       key: infracost-api-key
                 {{- if .Values.job.infracostPricingAPIEndpoint }}

--- a/charts/cloud-pricing-api/templates/job-init.yaml
+++ b/charts/cloud-pricing-api/templates/job-init.yaml
@@ -61,7 +61,7 @@ spec:
                   {{- if not .Values.existingSecretAPIKey }}
                   name: {{ include "cloud-pricing-api.fullname" . }}
                   {{- else }}
-                  name: {{ .Values.apiKey.existingSecret }}
+                  name: {{ .Values.existingSecretAPIKey }}
                   {{- end }}
                   key: infracost-api-key
             {{- if not .Values.api.disableSelfHostedInfracostAPIKey }}

--- a/charts/cloud-pricing-api/values.yaml
+++ b/charts/cloud-pricing-api/values.yaml
@@ -106,7 +106,7 @@ postgresql:
   postgresqlDatabase: cloudpricingapi
   # -- Name of the PostgreSQL user
   postgresqlUsername: cloudpricingapi
-  # -- Details of external PostgreSQL server, such as AWS RDS, to use (assuming you've set postgresql.enabled to false)
+  # -- Details of external PostgreSQL server, such as AWS RDS, to use (assuming you've set postgresql.enabled to false. NOTE: In this case if existingSecret is set, it will be used for external.password)
   external: {}
   #   host:
   #   port:


### PR DESCRIPTION
* Allow .Values.postgresql.existingSecret to be used for external PostGRES DB password (i.e. when .Values.postgresql.enabled == False)
* Fixed typos from .Values.apiKey.existingSecret to .Values.existingSecretAPIKey
* Tested as working with external PostGRES and existing secret

Please see PR for context: https://github.com/infracost/helm-charts/pull/21 @endriu0 