### PR TITLE
Use topologySpreadConstraints to evenly distribute pods

### DIFF
--- a/charts/cloud-pricing-api/Chart.yaml
+++ b/charts/cloud-pricing-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.10
+version: 0.5.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloud-pricing-api/README.md
+++ b/charts/cloud-pricing-api/README.md
@@ -1,6 +1,6 @@
 # Cloud Pricing API
 
-![Version: 0.5.10](https://img.shields.io/badge/Version-0.5.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.8](https://img.shields.io/badge/AppVersion-v0.3.8-informational?style=flat-square)
+![Version: 0.5.11](https://img.shields.io/badge/Version-0.5.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.8](https://img.shields.io/badge/AppVersion-v0.3.8-informational?style=flat-square)
 
 A Helm chart for running the Infracost [Cloud Pricing API](https://github.com/infracost/cloud-pricing-api).
 
@@ -100,6 +100,10 @@ The best way to get instructions for configuring Infracost to use the self-hoste
 | api.resources | object | `{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | API resource limits and requests, our request recommendations are based on minimal requirements and the limit recommendations are based on usage in a high-traffic production environment. If you are running on environments like Minikube you may wish to remove these recommendations. |
 | api.selfHostedInfracostAPIKey | string | `""` | A 32 character API token that your Infracost CLI users will use to authenticate when calling your self-hosted Cloud Pricing API. If left empty, the helm chat will generate one for you. If you ever need to rotate the API key, you can simply update `self-hosted-infracost-api-key` in the `cloud-pricing-api` secret and restart the application. |
 | api.tolerations | list | `[]` | API tolerations |
+| api.topologySpread.enabled | bool | `false` | Enable Pods spreading among zones |
+| api.topologySpread.maxSkew | int | `1` | Degree to which Pods may be unevenly distributed. See [docs](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraint-definition). |
+| api.topologySpread.topologyKey | string | `"topology.kubernetes.io/zone"` | Key of node labels |
+| api.topologySpread.whenUnsatisfiable | string | `"ScheduleAnyway"` | How to deal with a Pod if it doesn't satisfy the spread constraint |
 | existingSecretAPIKey | string | `""` | If you'd rather use your own secret you can leave the above empty and instead specify the name of your secret below |
 | fullnameOverride | string | `""` | Full name override for the deployed app |
 | image.pullPolicy | string | `"Always"` | Image pull policy pullPolicy: IfNotPresent |

--- a/charts/cloud-pricing-api/templates/api-deployment.yaml
+++ b/charts/cloud-pricing-api/templates/api-deployment.yaml
@@ -20,6 +20,15 @@ spec:
       labels:
         {{- include "cloud-pricing-api.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.api.topologySpread.enabled }}
+      topologySpreadConstraints:
+      - maxSkew: {{ .Values.api.topologySpread.maxSkew }}
+        topologyKey: "{{ .Values.api.topologySpread.topologyKey }}"
+        whenUnsatisfiable: {{ .Values.api.topologySpread.whenUnsatisfiable }}
+        labelSelector:
+          matchLabels:
+            {{- include "cloud-pricing-api.selectorLabels" . | nindent 12 }}
+      {{- end }}
       {{- if .Values.api.extraVolumes }}
       volumes:
       {{- toYaml .Values.api.extraVolumes | nindent 6 }}

--- a/charts/cloud-pricing-api/values.yaml
+++ b/charts/cloud-pricing-api/values.yaml
@@ -128,12 +128,15 @@ api:
   # -- Replica count
   replicaCount: 1
   
-  # -- Spread pods evenly accross all zones
   topologySpread:
-    enabled: true
-    topologyKey: topology.kubernetes.io/zone
+    # -- Enable Pods spreading among zones
+    enabled: false
+    # -- Degree to which Pods may be unevenly distributed. See [docs](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraint-definition).
     maxSkew : 1
-    whenUnsatisfiable: DoNotSchedule
+    # -- Key of node labels
+    topologyKey: topology.kubernetes.io/zone
+    # -- How to deal with a Pod if it doesn't satisfy the spread constraint
+    whenUnsatisfiable: ScheduleAnyway
 
   livenessProbe:
     # -- Enable the liveness probe

--- a/charts/cloud-pricing-api/values.yaml
+++ b/charts/cloud-pricing-api/values.yaml
@@ -127,6 +127,13 @@ api:
 
   # -- Replica count
   replicaCount: 1
+  
+  # -- Spread pods evenly accross all zones
+  topologySpread:
+    enabled: true
+    topologyKey: topology.kubernetes.io/zone
+    maxSkew : 1
+    whenUnsatisfiable: DoNotSchedule
 
   livenessProbe:
     # -- Enable the liveness probe


### PR DESCRIPTION
Make it possible to use `topologySpreadConstraints` block in Deployment to evenly distribute pods among zones/regions/hostnames.