### PR TITLE
Feat: Updating Chart to Allow for Different CronJob Image/Tag

### DIFF
--- a/charts/cloud-pricing-api/Chart.yaml
+++ b/charts/cloud-pricing-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.7
+version: 0.6.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloud-pricing-api/README.md
+++ b/charts/cloud-pricing-api/README.md
@@ -124,6 +124,7 @@ The best way to get instructions for configuring Infracost to use the self-hoste
 | job.extraVolumeMounts | list | `[]` | Optionally specify additional volume mounts for the container |
 | job.extraVolumes | list | `[]` | Optionally specify additional volumes |
 | job.failedJobsHistoryLimit | int | `5` | History limit for failed jobs |
+| job.image | string | `"infracost/cloud-pricing-api"` | Cloud Pricing API image |
 | job.logLevel | string | `"info"` | Set this to debug, info, warn or error |
 | job.nodeSelector | object | `{}` | Job node selector |
 | job.resources | object | `{"limits":{"cpu":"200m","memory":"640Mi"},"requests":{"cpu":"50m","memory":"128Mi"}}` | Job resource limits and requests. If you are running on environments like Minikube you may wish to remove these recommendations. |
@@ -131,6 +132,7 @@ The best way to get instructions for configuring Infracost to use the self-hoste
 | job.schedule | string | `"0 4 * * SUN"` | Job schedule |
 | job.startingDeadlineSeconds | int | `3600` | Deadline seconds for the job starting |
 | job.successfulJobsHistoryLimit | int | `5` | History limit for successful jobs |
+| job.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | job.tolerations | list | `[]` | Job tolerations |
 | job.ttlSecondsAfterFinished | int | `nil` | Marks the jobs as eligible for automatic cleanup after the job has finished and the TTL has expired, whether the job is successful or failed. This avoids the need to delete the init job before upgrading the Helm chart. |
 | nameOverride | string | `""` | Name override for the deployed app |

--- a/charts/cloud-pricing-api/README.md
+++ b/charts/cloud-pricing-api/README.md
@@ -1,6 +1,6 @@
 # Cloud Pricing API
 
-![Version: 0.6.7](https://img.shields.io/badge/Version-0.6.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.16](https://img.shields.io/badge/AppVersion-0.3.16-informational?style=flat-square)
+![Version: 0.6.8](https://img.shields.io/badge/Version-0.6.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.16](https://img.shields.io/badge/AppVersion-0.3.16-informational?style=flat-square)
 
 A Helm chart for running the Infracost [Cloud Pricing API](https://github.com/infracost/cloud-pricing-api).
 

--- a/charts/cloud-pricing-api/templates/job-cron.yaml
+++ b/charts/cloud-pricing-api/templates/job-cron.yaml
@@ -43,7 +43,11 @@ spec:
             - name: {{ .Chart.Name }}
               securityContext:
                 {{- toYaml .Values.securityContext | nindent 16 }}
+              {{- if not (.Values.job.image.repository) and not (.Values.job.image.tag) }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              {{- else }}
+              image: "{{ .Values.job.image.repository }}:{{ .Values.job.image.tag | default .Chart.AppVersion }}"
+              {{- end}}
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: ["npm", "run", "job:update"]
               resources:

--- a/charts/cloud-pricing-api/templates/job-init.yaml
+++ b/charts/cloud-pricing-api/templates/job-init.yaml
@@ -36,7 +36,11 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 16 }}
+          {{- if not (.Values.job.image.repository) and not (.Values.job.image.tag) }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- else }}
+          image: "{{ .Values.job.image.repository }}:{{ .Values.job.image.tag | default .Chart.AppVersion }}"
+          {{- end}}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["npm",  "run", "job:init"]
           resources:

--- a/charts/cloud-pricing-api/values.yaml
+++ b/charts/cloud-pricing-api/values.yaml
@@ -213,6 +213,10 @@ api:
   #     mountPath: /path/in/container
 
 job:
+  # -- Cloud Pricing API image
+  image: infracost/cloud-pricing-api
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: ""
   # -- Run the job as a one-off on deploy
   runInitJob: true
   # -- Job backoff limit


### PR DESCRIPTION
These changes are to directly address [this](https://github.com/infracost/helm-charts/issues/18) issue which even when upgrading to latest chart version only the image with the tag of `bullseye-test` works within getting the error mentioned in the issue.